### PR TITLE
chore(release): Refresh plugin metadata and cut v2.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code (machine-local instructions)
+CLAUDE.local.md
+
 # Python
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented here. The format loosely foll
 `version:` field in the `usage_display.py` docstring.
 
 
+## [2.5.2]
+
+- **Metadata refresh (no behavior changes).** The docstring frontmatter gains `author_url`, `git_url` and `license`, so the pasted file carries its own provenance, and the description now mentions that workspace/custom ("agent") models resolve context and cost via their base model. The NOTE assumption block was re-verified against Open WebUI v0.10.2 and one stale clause corrected: `message["content"]` is not persisted for *non-streaming* completions either — at 0.10.x both save paths write only the structured `output` array. Comment-only: the content-first / `output`-fallback extraction order already handled this correctly.
+
 ## [2.5.1]
 
 - **`context_size_map` now takes precedence over the live models.dev fetch.** It was previously merged into the built-in table, which is consulted *after* the models.dev lookup — so with `fetch_context_from_modelsdev` enabled, an automatic remote match silently overrode your explicit manual entry. It's now resolved in its own tier, right after `override`/`num_ctx` and **before** models.dev and the static table (source `user_map` in the debug payload), matching how `price_map` already beats models.dev for cost. Consequences: a map entry now wins outright on any substring match (even against a longer static/models.dev key — the same semantics as `price_map`); a falsy size (`0`) is skipped and falls through; parsing is per-entry tolerant (one bad value drops only that entry). It's returned uncached, so edits take effect immediately.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+A **single-file Open WebUI filter plugin**. The deliverable is `usage_display.py` (~2000 lines),
+which a user pastes into Open WebUI **Admin → Functions**. There is **no build step and no
+install** — everything else in the repo (tests, docs, CI) is scaffolding around that one file. It
+is published on the community store (<https://openwebui.com/posts/token_usage_display_a94ea72f>)
+and listed in the official Open WebUI docs Community Plugins catalog
+(<https://docs.openwebui.com/features/extensibility/community/>).
+
+## Critical rules
+
+- **Keep it one copy-pasteable file with zero runtime dependencies.** Never split the plugin into
+  modules. Its only optional imports (`tiktoken`, `aiohttp`) are **soft-imported** so the plugin
+  loads without them.
+- **Never add a `requirements:` line to the docstring frontmatter.** It triggers a per-plugin
+  `pip install` inside OWUI that fails in uvx/LXC deployments and blocks the plugin from loading
+  (real user bug reports) — soft imports exist precisely to avoid it.
+- **Do not reflow the docstring frontmatter.** OWUI parses strictly one `key: value` per line
+  (`utils/plugin.py:extract_frontmatter`); wrapping a long line truncates the metadata. This is
+  why `E501` is ignored for `usage_display.py`.
+- **Verify every claim about OWUI behavior against real OWUI source, not memory or docs.** The
+  data model shifts between versions. A read-only local clone path and freshness-check commands
+  live in `CLAUDE.local.md`; the verified map is in the imported `docs/owui-map.md`. If the clone
+  is stale relative to the latest OWUI release, say so — the user updates it himself.
+
+## Deep-dive references (imported, always loaded)
+
+- Plugin internals — pipeline, valves, resolution chains, token/cache semantics, debug payload,
+  edge-case catalog with covering tests: @docs/plugin-internals.md
+- Open WebUI source map — filter machinery, request lifecycle, usage normalization, persistence,
+  events, frontend constraints (verified against v0.10.2): @docs/owui-map.md
+
+## Commands
+
+The dev environment lives in `.venv`; the `Makefile` drives everything through `.venv/bin/python`.
+
+```bash
+python -m venv .venv && make install-dev   # one-time setup
+make pre-commit                            # the full gate: lint + typecheck + test-cov
+make lint        # ruff check + ruff format --check
+make format      # ruff format + ruff check --fix (auto-fix)
+make typecheck   # mypy --strict
+make test        # pytest
+make test-cov    # pytest with coverage (term-missing + HTML in htmlcov/)
+```
+
+`make pre-commit` must be green before any change is done. It enforces **mypy strict** and a
+**coverage floor of 95%** (`pyproject.toml` `fail_under = 95`). CI (`.github/workflows/ci.yml`,
+single `gate` job) runs the same gate across Python 3.11–3.14 on pushes to `main` and all PRs.
+
+Run a single test: `.venv/bin/python -m pytest tests/test_usage_display.py::test_render_input`
+(or `-k <substring>`). The suite has no network and no Open WebUI runtime — it is fast.
+
+## Releasing a change
+
+- The version has a **single source of truth**: the `version:` field in the `usage_display.py`
+  module docstring. When bumping it, mirror it in `pyproject.toml` `version` and add a matching
+  top entry in `CHANGELOG.md`. (`required_open_webui_version: 0.9.0` in the same docstring is the
+  compat floor; native provider cost needs 0.10.0+.)
+- **Tag each release `vX.Y.Z`** matching the CHANGELOG entry (existing convention: `v2.0.0` …
+  `v2.5.1`); there is no automated release workflow — tagging is manual.
+- The community-store post text is maintained in `docs/community-post.md`; publishing to the store
+  post (URL above) is a manual copy-paste done by the user.
+
+## Architecture (summary — details live in the imports above)
+
+- `class Filter` implements the OWUI filter contract: async `inlet` (stashes wall-clock start and
+  a `num_ctx` hint) and async `outlet` (the orchestrator: gates → extract tokens → timing →
+  context → cost → build stats → emit a `status` event). Both resolver calls are individually
+  exception-guarded — the plugin must never break the response pipeline.
+- Config is two Pydantic models: `Valves` (admin — all toggles, ordering, cost/context maps and
+  URLs) and `UserValves` (per-user `enabled` kill-switch only; per-user customization was
+  deliberately rolled back).
+- The stats line is a dispatch table (`_STATS_RENDERERS`, 13 metric keys, fixed 6-arg renderer
+  signature). Key rule: **`show_*` valves gate visibility; `display_order` only sorts.**
+- Context, price and model identity resolve through priority-ordered fallback chains
+  (short-circuit on first hit); table lookups use longest-key case-insensitive substring match.
+  Workspace/"agent" models resolve via **`base_model_id`**.
+- The **NOTE block** at `usage_display.py:14-38` is the source-verified contract with OWUI's data
+  model. Reconcile any token/cost/context change against it — and re-verify it against real OWUI
+  source for the targeted version.
+- Live network access (models.dev context/prices, llama.cpp probe) is opt-in via valves and
+  TTL-cached in module-level dicts; all fetch failures degrade silently.
+- `debug_mode` emits a sanitized diagnostic payload as a copyable `citation` event + stdout — the
+  primary support tool. Sanitization is whitelist-based; never include raw `__model__`/
+  `__metadata__` dicts (they carry the prompt and user/session ids).
+
+## Testing approach
+
+OWUI plugins are not importable packages, so `tests/conftest.py` loads `usage_display.py` via
+`SourceFileLoader` and exposes it through the session-scoped **`usage_display_module`** fixture;
+tests (172 collected from `tests/test_usage_display.py`) call the module's functions directly. There is **no
+OWUI runtime and no network** — `tiktoken`/`aiohttp` and all provider payloads are faked (fakes
+and `make_*` builders live at the top of the test file). `pydantic` is pinned in
+`requirements-dev.txt` to the version OWUI ships (`2.13.4` for OWUI 0.10.2), so the plugin is
+tested against the same pydantic it runs on in production — keep that pin tracking OWUI's, and
+don't let a Dependabot bump drift it silently (Dependabot runs weekly for pip and GitHub Actions).
+
+## Conventions
+
+- Line length 120; ruff lint is broad (see `pyproject.toml` `[tool.ruff.lint]`). The per-file
+  ignores on `usage_display.py` (`E501`, `PLR0913`, `PLR0912`, `PLR2004`, `SIM117`) are
+  intentional and documented inline.
+- Non-ASCII glyphs (`·`, emoji icons, `≈`, `Σ`) in strings are intentional (`RUF001/2/3` ignored).
+- `_STATIC_CONTEXT_SIZES` and `_STATIC_PRICES` are hand-maintained offline seed tables (from
+  models.dev, seeded 2026-07) — refresh them periodically; keep the `llama` family out of
+  `_STATIC_PRICES` on purpose (free on Meta's API, paid on Groq/Together — a hardcoded $0 would
+  lie).
+- Issue templates ask reporters for the sanitized `debug_mode` payload; the PR template requires a
+  version bump + CHANGELOG entry for user-facing changes and naming the OWUI version verified
+  against.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A filter plugin for [Open WebUI](https://openwebui.com) that shows detailed toke
 timing and cost statistics below each AI response — token counts (input/output/total, reasoning,
 cached, audio), context-window utilization, generation time, tokens/second and message/chat cost.
 
+Recommended in the official Open WebUI documentation — see the
+[Community Plugins catalog](https://docs.openwebui.com/features/extensibility/community/). Install
+it from the [community store post](https://openwebui.com/posts/token_usage_display_a94ea72f) or
+straight from this repo.
+
 ![Token usage & cost stats line under an Open WebUI response](docs/screenshot.png)
 
 ```text
@@ -148,7 +153,9 @@ under the message (also mirrored to the server log). Its `cost_debug`, `context_
 
 ## Links
 
-- Open WebUI community post: <https://openwebui.com/posts/a94ea72f-8a84-4686-ad36-dd51342cc45d>
+- Open WebUI community post: <https://openwebui.com/posts/token_usage_display_a94ea72f>
+- Official Open WebUI docs — Community Plugins catalog:
+  <https://docs.openwebui.com/features/extensibility/community/>
 - Full changelog: [CHANGELOG.md](CHANGELOG.md)
 
 ## Contributing

--- a/docs/owui-map.md
+++ b/docs/owui-map.md
@@ -1,0 +1,159 @@
+# Open WebUI source map (maintainer reference)
+
+A navigation map of the Open WebUI codebase covering everything this plugin depends on: the filter
+machinery, the request lifecycle, usage normalization, persistence, events, and the frontend pieces
+that constrain the plugin's UX. Paths are relative to the Open WebUI repo root.
+
+**Verified against Open WebUI `v0.10.2`** (commit `ecd48e2f7`, released 2026-07-01). OWUI internals
+shift between versions — before relying on any claim below, re-check it against a current checkout
+(the local clone path and freshness-check commands live in `CLAUDE.local.md`).
+
+## Repo layout
+
+- `backend/open_webui/main.py` — FastAPI app; top-level routes (`/api/chat/completions`,
+  `/api/chat/completed`, `/api/tasks/*`); builds the request `metadata` dict.
+- `backend/open_webui/utils/` — cross-cutting logic: `middleware.py` (~5380 lines, the request
+  lifecycle brain), `filter.py`, `plugin.py`, `chat.py`, `models.py`, `payload.py`, `response.py`.
+- `backend/open_webui/routers/` — one file per REST resource: `functions.py`, `models.py`,
+  `openai.py`, `ollama.py`, `chats.py`, `tasks.py`, `analytics.py`, ...
+- `backend/open_webui/models/` — DB layer: `functions.py`, `chats.py` (legacy JSON blob),
+  `chat_messages.py` (normalized message table, dual-written), `models.py`.
+- `backend/open_webui/socket/main.py` — Socket.IO server, event emitter/caller.
+- `src/lib/components/chat/` — chat UI: `Chat.svelte` (frontend mirror of middleware),
+  `Messages/ResponseMessage.svelte` and friends.
+- `src/lib/apis/` — thin fetch wrappers per backend resource.
+
+## Filter-plugin machinery
+
+- `utils/plugin.py` — `extract_frontmatter:150` parses the docstring frontmatter, strictly one
+  `key: value` per line (regex `^\s*([a-z_]+):\s*(.*)\s*$` — this is why frontmatter lines must
+  never be wrapped). `load_function_module_by_id:253` `exec()`s the source into a fresh module;
+  a `Filter` class makes it type `filter`; a load error force-deactivates the function (line 301).
+  `install_frontmatter_requirements:411` pip-installs anything in a `requirements:` frontmatter
+  line — the reason this plugin must never declare one. `get_function_module_from_cache:364`
+  caches modules per app state; the `stream` hook uses cache-only loads for performance.
+- `utils/filter.py` — `get_sorted_filter_ids:21` merges global filters + the model's
+  `info.meta.filterIds`, resolves `Valves.priority`, sorts by `(priority, filter_id)`.
+  `process_filter_functions:66` dispatches `inlet`/`outlet`/`stream`: instantiates `Valves` from
+  the DB, injects `__user__["valves"]` from `UserValves`, and passes **only the dunder kwargs the
+  handler's signature declares** (`inspect.signature`, lines 92–105). Each filter's return value
+  becomes the next filter's input.
+- `models/functions.py` — `Function` table: `valves` is JSON, encrypted (`utils/valves.py`);
+  per-user valves live inside `User.settings.functions.valves[id]`, not a separate table (line 346).
+- `routers/functions.py` — admin API: `POST /id/{id}/toggle` (active), `POST /id/{id}/toggle/global`
+  (run-on-every-chat). Per-model attachment is stored on the *model* (`info.meta.filterIds`), not
+  on the function.
+- `required_open_webui_version` is enforced **only client-side** at save time
+  (`src/routes/(app)/admin/functions/create/+page.svelte:23`); the backend never checks it.
+
+## Dunder kwargs available to filter hooks
+
+A handler receives only the subset its signature names. Built at `middleware.py:2312-2322` (inlet),
+`:3364-3372` (outlet), `:3614-3618` (stream).
+
+| kwarg | inlet | outlet | stream | notes |
+|---|---|---|---|---|
+| `__event_emitter__`, `__event_call__`, `__user__`, `__metadata__`, `__request__`, `__model__` | yes | yes | yes | `__metadata__` and `body["metadata"]` are the same dict object |
+| `__oauth_token__` | yes | no | yes | |
+| `__chat_id__`, `__message_id__` | yes | no | no | duplicated inside `__metadata__` anyway |
+| `__id__` | yes | yes | yes | the filter's own function id (`filter.py:102`) |
+| `__body__` | no | no | yes | full form_data alongside the chunk (`middleware.py:4040`) |
+
+**`__model__` caveats:** raw (non-customized) models have **no `info` key** at all
+(`utils/models.py:33-51`) — always `.get("info") or {}`. `info.params` (temperature, num_ctx, ...)
+is **stripped before filters see the model** (`utils/models.py:163-164, 202-204`, "Remove params to
+avoid exposing sensitive info") — generation params and base URLs are unavailable in outlet.
+
+**`__metadata__` is sensitive:** it carries `user_message` (the raw prompt), `user_id`,
+`user_agent`, `session_id`, `chat_id`, `variables`, `files` (`main.py:1130-1157`). Never dump it
+raw into anything user-shareable — whitelist fields instead.
+
+## Request lifecycle
+
+1. Frontend `Chat.svelte:2548` → `POST /api/chat/completions`. `stream_options.include_usage` is
+   sent **only when the model's `capabilities.usage` flag is on** (`Chat.svelte:2604-2610`) — the
+   root cause of most "no tokens shown in streaming" reports.
+2. `main.py:chat_completion:1009` builds `metadata` (`:1130-1157`), resolves arena/custom models,
+   generates ids; `process_chat(...)` (`:1473`) then runs the pipeline.
+3. `middleware.py:process_chat_payload:2163` — `apply_params_to_form_data:1872` runs **before**
+   inlet filters and, for Ollama-owned models, moves params into `form_data["options"]` (including
+   `num_ctx`, `:1903-1905`). Inlet filters run at `:2424-2434`. `features` is popped into
+   `extra_params["__features__"]` only *after* inlet (`:2438-2439`).
+4. Provider routers substitute `base_model_id` right before the upstream call
+   (`routers/openai.py:1134-1139`, `routers/ollama.py:1106-1108` and siblings) and apply model
+   params. Ollama usage is converted to OpenAI shape by
+   `utils/response.py:convert_ollama_usage_to_openai:156` (`eval_count` → tokens, duration fields).
+5. **Outlet filters run inline** in `middleware.py:outlet_filter_handler:3273-3416`: it builds the
+   outlet body (`{model, messages, chat_id, session_id, id}`, messages carry per-message `usage`
+   and `info`, `:3336-3355`), runs `process_filter_functions(filter_type="outlet")`, persists
+   changes and emits `chat:outlet`. Called from both the non-streaming handler (`:3571, :3591`) and
+   end-of-stream (`:5278, :5357`); the raw-API path is gated by `ENABLE_API_OUTLET_FILTERS`
+   (default on). `POST /api/chat/completed` still exists (`main.py:1732`) but is **deprecated** —
+   the frontend no longer calls it.
+6. **Task requests never reach filter functions.** Title/tags/follow-up/etc. generation
+   (`routers/tasks.py`, marks `metadata["task"]`) calls `generate_chat_completion()` directly
+   (`utils/chat.py:152-305`), which runs no Function-filter inlet/outlet at all. The plugin's task
+   guard is defensive belt-and-suspenders.
+7. **Usage capture:** streaming accumulates `merge_usage(...)` per chunk (`middleware.py:4125`
+   Responses API; `:4151-4154` Chat Completions, where llama.cpp `timings` are folded into usage);
+   non-streaming normalizes once (`:3535, :3585`). The final `usage` rides the `chat:completion`
+   "done" event and is persisted with the message (`:5222-5276`).
+8. **Structured `output` arrays** are built by `handle_responses_streaming_event:424` (Responses
+   API), inline tag handlers (reasoning/solution tags, `:3637+`), or synthesized from
+   `choices[0].message` for non-streaming (`:3488-3521`). `utils/misc.py:convert_output_to_messages:223`
+   is the canonical output→text converter.
+
+## Usage normalization (`utils/response.py`)
+
+- `normalize_usage:13` — always derives `input_tokens`/`output_tokens`/`total_tokens` (from
+  `prompt_tokens`/`completion_tokens`, Ollama `prompt_eval_count`/`eval_count`, llama.cpp
+  `prompt_n`/`predicted_n`), **preserving** all original provider keys alongside.
+- `merge_usage:104` — multi-round tool turns: sums `USAGE_TOKEN_KEYS`, `USAGE_COST_KEYS`
+  (`cost, total_cost, input_cost, output_cost, prompt_cost, completion_cost` — how proxy-reported
+  cost survives normalization) and the four `*_tokens_details` dicts. Top-level Anthropic cache
+  fields and Ollama duration fields are in none of those sets → **last round wins** for
+  cache/timing. This is the OWUI limitation the plugin documents rather than fixes.
+
+## Events (`socket/main.py`)
+
+`get_event_emitter:919` needs `user_id` + `chat_id` + `message_id`; emits over Socket.IO and — for
+persistent chats — writes DB side effects by `data["type"]`:
+
+- `status` → **appended** to `statusHistory` (`models/chats.py:796`); the UI shows only the latest
+  entry collapsed, but the full history persists and is expandable.
+- `source` / `citation` → appended to `message.sources` (`:1014-1031`), **only when `data.type` is
+  absent** — the persistence trick the plugin's debug citation relies on.
+- `message` / `replace` → append to / overwrite `message.content`.
+- Temporary chats (`chat_id.startswith("local:")` — prefix, not equality) skip all persistence.
+
+`get_event_call:1039` — request/response calls into a live WS session (dialogs, client-side JS).
+
+## Persistence and the message data model
+
+- `models/chats.py:upsert_message_to_chat_by_id_and_message_id:704` — the single message-write
+  path; dual-writes the normalized `chat_message` table (`ChatMessages.upsert_message`, non-fatal).
+- `models/chat_messages.py` — `usage` is a **first-class column** (`:80-123`).
+  `get_messages_map_by_chat_id:303-305` is the `info` mirror writer:
+  `if "usage" in msg: msg["info"] = {"usage": msg["usage"]}` — `info` and `usage` are the *same
+  data*; reading both double-counts. This is why the plugin ignores `info`.
+- **`content` is empty for BOTH streaming and non-streaming at v0.10.2.** The assistant placeholder
+  starts as `''` (`main.py:1443`) and every save path writes `output`/`usage` only
+  (`middleware.py:5228-5242` streaming, `:3538-3547` non-streaming). All visible text lives in the
+  structured `output` array; a content-first reader must always fall through to `output`.
+- Aggregate token analytics (independent of this plugin):
+  `chat_messages.py:get_token_usage_by_model:489`, exposed via `routers/analytics.py`.
+
+## Frontend constraints that shaped the plugin
+
+- `Chat.svelte:chatEventHandler:610` — `status` pushes onto `message.statusHistory` (`:621-626`);
+  `chat:completion` sets `message.usage` (`:2013`).
+- `Messages/ResponseMessage/StatusHistory/StatusItem.svelte` — status text renders plain-text with
+  a hardcoded `line-clamp-1` and is not selectable → **multi-line / markdown / copyable debug output
+  in the status line is impossible**.
+- `ContentRenderer.svelte:265-312` — `content` renders **only when `output` is empty**; on 0.10.x
+  responses `output` is non-empty → appending debug text to `content` is invisible.
+- `Citations.svelte` → `CitationModal.svelte` — sources render as Markdown with a Copy button on
+  code blocks (`CodeBlock.svelte:518`) → the reason `debug_mode` ships its payload as a `citation`
+  event (copyable, persisted) with stdout as fallback.
+- `ResponseMessage.svelte:1160-1184` — OWUI's own built-in usage tooltip (pretty-printed
+  `message.usage`) — the native UI this plugin complements.

--- a/docs/plugin-internals.md
+++ b/docs/plugin-internals.md
@@ -1,0 +1,236 @@
+# usage_display.py internals (maintainer reference)
+
+How the plugin works end-to-end, why it is designed this way, and the edge-case catalog with the
+covering tests. Line numbers refer to plugin v2.5.2 (1959 lines); treat them as anchors, not gospel.
+
+## Pipeline
+
+### `inlet()` — `usage_display.py:894-928`
+
+Runs before the LLM call. Computes a timing key `f"{chat_id}:{message_id}"` from `__metadata__`
+(falling back to `f"fallback:{id(body)}"` when both ids are absent, line 903), stores
+`time.time()` in module-level `_request_timings`, and captures a `num_ctx` hint from
+`body["num_ctx"]` / `body["options"]["num_ctx"]` / `body["params"]["num_ctx"]` (the `options` path
+is the live one for Ollama; `params` is a dead-path safety net — OWUI pops it before inlet).
+The key, start time and hint are mirrored into both `body["metadata"]` and `__metadata__`
+(`_tud_timing_key`, `_tud_start`, `_tud_num_ctx`) so outlet can recover them even if the module
+dict was lost (server restart, multi-worker).
+
+### `outlet()` — `usage_display.py:932-1009`
+
+Orchestration order (each step degrades gracefully, never raises out):
+
+1. **UserValves kill-switch** (`:940-942`) — `enabled=False` returns the body untouched.
+2. **Background-task guard** (`:945-955`) — skips the 7 `metadata["task"]` values
+   (`title_generation`, `tags_generation`, `follow_up_generation`, `emoji_generation`,
+   `query_generation`, `autocomplete_generation`, `moa_response_generation`). Defensive only: at
+   OWUI v0.10.2 task requests never run filter functions at all (see `docs/owui-map.md`).
+3. **Message gates** (`:957-962`) — empty `messages` or no assistant message → return.
+4. `_resolve_wall_clock` (`:966`) → `_extract_tokens` (`:969`) → `_resolve_timing` (`:970`).
+5. `_resolve_context` (`:971-974`) and `_resolve_cost` (`:977-980`) — each wrapped in its own
+   `try/except Exception` with a sentinel fallback (`source="error"` / all-`None` cost), so a
+   resolver bug can never kill the response pipeline.
+6. `_build_stats` (`:982`) joins the parts with `valves.separator`; `debug_mode` appends `(debug)`.
+7. Emits `{"type": "status", "data": {"description": ..., "done": True}}` (`:986-992`), then in
+   debug mode `_emit_debug` (`:994-1007`) emits a `citation` event (copyable modal, persisted) and
+   mirrors the pretty JSON to server stdout as `[TUD debug]`.
+
+## The OWUI contract (NOTE block) and its verification status
+
+The NOTE block at `usage_display.py:14-38` is the source-verified contract with OWUI. Verified
+against OWUI v0.10.2 (2026-07):
+
+- Normalized triple guaranteed on every save path — **confirmed** (`utils/response.py:13-51,104`).
+- `info` is a redundant mirror of `usage` — **confirmed** (`models/chat_messages.py:303-305`).
+- Detail keys differ per API shape, passed through untouched — **confirmed**.
+- `merge_usage` sums tokens/cost/details but last-wins for Anthropic top-level cache and Ollama
+  durations — **confirmed** (they are in none of the merge key sets).
+- `content` is not persisted at 0.10.x for either mode (`''` placeholder; every save path writes
+  `output` only) — **confirmed**; the NOTE block was corrected accordingly in v2.5.2 (an earlier
+  clause wrongly claimed `content` is present for non-streaming responses).
+
+Any change to token/cost/context reading must be reconciled against this block AND re-verified
+against real OWUI source of the version being targeted — never against memory or docs.
+
+## Valves
+
+Grouped inventory (`Valves` at `:755-884`, `UserValves` at `:886-887`). Defaults in parentheses
+when non-obvious:
+
+- **Visibility** — `show_input_tokens`, `show_output_tokens`, `show_total_tokens`,
+  `show_generation_time`, `show_tokens_per_second`, `show_reasoning_tokens`, `show_cached_tokens`,
+  `show_audio_tokens` (False), `show_model_name`, `show_data_source` (False),
+  `show_context_window`, `show_cumulative_cost`. Message cost has **no** `show_*` — its visibility
+  is `cost_mode` itself.
+- **Presentation** — `display_order` (pre-filled full 13-key order), `separator` (`" · "`),
+  `icon_style` (`emoji`/`simple`/`off`), `compact_numbers` (False).
+- **Estimation** — `fallback_to_tiktoken` (True), `count_all_messages_for_input` (True).
+- **Context** — `context_size_override` (0 = auto), `context_size_map` (JSON string),
+  `fetch_context_from_modelsdev` (**False** — privacy: no network without consent),
+  `modelsdev_url`, `modelsdev_ttl` (86400), `context_warn_percent` (30),
+  `context_critical_percent` (70), `llamacpp_url`, `llama_swap_url` (both ""), `context_probe_ttl`
+  (600).
+- **Cost** — `cost_mode` (`auto`; Literal `off`/`auto`/`estimate`), `cost_min_display` (0.0),
+  `price_map` (JSON string), `fetch_prices_from_modelsdev` (True — but only reachable in
+  `estimate` mode, which is itself an explicit choice), `modelsdev_api_url`.
+- **Misc** — `priority` (10), `debug_mode` (False).
+- **UserValves** — `enabled` (True). Per-user display customization was deliberately rolled back:
+  everything else is admin-only.
+
+## Renderer dispatch
+
+`_STATS_RENDERERS` (`:737-751`) maps 13 keys (`input`, `output`, `total`, `reasoning`, `cached`,
+`audio`, `context`, `time`, `tps`, `cost`, `cost_total`, `model`, `source`) to `_render_*`
+functions sharing a fixed 6-arg signature `(v, tokens, timing, ctx, cost, model)` — the reason
+`PLR0913` is suppressed. `_build_stats` (`:1708-1736`) walks the resolved order, drops `None`
+results, and suppresses a line consisting solely of `source` parts (`:1734-1735`).
+
+Rules: **`show_*` valves gate visibility; `display_order` only sorts.** `_resolve_display_order`
+(`:451-458`) always returns a full 13-key permutation — removed keys move to the end, unknown keys
+are ignored (surfaced only in the debug payload). To add a metric: add a `show_*` valve, write a
+6-arg `_render_*`, register it in `_STATS_RENDERERS`, append the key to `_DEFAULT_ORDER`, add an
+icon to `_ICON_EMOJI`/`_ICON_SIMPLE`.
+
+## Resolution chains
+
+### Context size — `_context_size_for` (`:1251-1307`)
+
+1. `context_size_override` valve → 2. `num_ctx` hint from inlet → 3. user `context_size_map` →
+4. `_ctx_size_cache` hit → 5. live models.dev (opt-in) → 6. `_STATIC_CONTEXT_SIZES` →
+7. llama.cpp/llama-swap probe (opt-in). Tiers 1–3 return **uncached** on purpose (valve edits take
+effect immediately); only 5–7 results are cached (`max(60, context_probe_ttl)`). The user map was
+promoted above models.dev in v2.5.1 — an explicit user entry must never lose to a live lookup.
+
+### Cost — `_resolve_cost` (`:1429-1494`)
+
+- `off` — nothing computed, fetched or shown.
+- `auto` (default) — **only** `_native_cost(usage)`: the provider/proxy-reported cost that survives
+  OWUI's `USAGE_COST_KEYS` merge (OpenRouter, LiteLLM). Never estimates, never touches the network.
+- `estimate` — native first, else `_estimate_cost(tokens, price)` marked `≈`.
+- **Cumulative** (`💰Σ`): recomputed each turn by summing per-message `usage` over
+  `body["messages"]` — deliberately NOT a module-level accumulator (survives restarts, follows the
+  active branch on regenerate/edit). Suppressed when equal to the message cost. Caveat: historical
+  messages without native cost are estimated at the *current* model's price (history carries no
+  per-message model), hence the `≈`.
+- Cost math honors cache semantics: OpenAI-style cache is a **subset** of input
+  (`(input−cached)·in + cached·cache_read`), Anthropic-native cache is **additive on top**
+  (`input·in + cache_read·rate + cache_write·rate`). See `_cache_and_fresh` below.
+
+### Price — `_resolve_price` (`:1617-1635`)
+
+`price_map` valve → live models.dev `api.json` (per-provider prices) → `_STATIC_PRICES`. The
+`llama` family is deliberately absent from `_STATIC_PRICES`: Meta's own API is free but the same
+ids are paid on Groq/Together/Fireworks — hardcoding $0 would lie for paid hosts.
+
+### Model identity — `_resolve_model_id` (`:387-407`)
+
+`model["info"]["base_model_id"]` → `model["id"]` → `body["model"]`. Workspace/"agent" models thus
+resolve context and price via the real underlying LLM, so one map entry covers every agent on it.
+
+### Matching semantics
+
+`_longest_key_match` (`:357-371`): case-insensitive substring, longest key wins (`gpt-4o` beats
+`gpt-4`) — used for all static tables and user maps. `_modelsdev_match` (`:374-384`): exact id →
+bare last path segment (`openai/gpt-4o` → `gpt-4o`) → substring — used only for the two live
+models.dev tables. Classic failure: `claude-opus-4.8` (dot) does not substring-match key
+`claude-opus-4-8` (dash); `matched_key: null` in the debug payload is the primary signal for this.
+
+## Token extraction — `_extract_tokens` (`:1013-1072`)
+
+- Key priority: `input_tokens` → `prompt_tokens` → `prompt_eval_count` (Ollama) → `prompt_n`
+  (llama.cpp); analogous for output. Reasoning: `completion_tokens_details.reasoning_tokens` (Chat
+  Completions) → `output_tokens_details.reasoning_tokens` (Responses API). Audio: sum of the
+  in/out `audio_tokens` detail keys.
+- **Cache — `_cache_and_fresh` (`:1103-1142`), the subtlest logic.** `native_anthropic` = top-level
+  `cache_read_input_tokens`/`cache_creation_input_tokens` present AND no `*_tokens_details` cache
+  keys → cache is *on top* of reported input. Otherwise (OpenAI, or a proxy that folded Anthropic
+  cache into details) cache is a *subset*: `fresh_input = max(input − cached − cache_write, 0)`.
+  Getting this wrong double-counts behind LiteLLM (fixed in v2.2.0).
+- `_compute_total` (`:1144-1158`): `fresh_input + cached + cache_write + output`.
+- **tiktoken fallback** (`:1066-1101`): only when no API-reported tokens AND
+  `fallback_to_tiktoken` AND tiktoken importable. `_message_text` (`:291-306`) prefers `content`,
+  falls through to walking the structured `output` array (`_extract_output_text:268-288` — only
+  `type=="message"` items; `reasoning` items excluded so they are not double-counted). Input is
+  estimated over all non-assistant messages (or just the last user message).
+- **Timing — `_resolve_timing` (`:1198+`)**: provider-reported wins (Ollama
+  `eval_duration`/`response_token/s`, llama.cpp `predicted_ms`/`predicted_per_second`), else
+  wall-clock marked `~`. Wall-clock includes OWUI-side RAG/web-search time — a platform limitation
+  (no hook right before the LLM call).
+
+## Module state
+
+| Name | TTL | Purpose |
+|---|---|---|
+| `_request_timings` | self-cleaning | inlet→outlet wall clock; used entry popped, stale (>600s) purged on every call (`:1186-1194`) |
+| `_ctx_size_cache` | `max(60, context_probe_ttl)` | resolved sizes for the modelsdev/static/probe tiers only |
+| `_modelsdev_cache` | `modelsdev_ttl` (24h); `min(300, ttl)` on failure | live context table |
+| `_modelsdev_prices_cache` | same | live price table |
+
+`_STATIC_CONTEXT_SIZES` (`:85-167`) and `_STATIC_PRICES` (`:178-224`) are hand-maintained offline
+seed tables (seeded from models.dev, 2026-07) — **they go stale and need periodic refreshing**
+against models.dev. All three aiohttp fetchers catch broad `Exception` and degrade to `{}`/`None`.
+
+## Debug payload — `_emit_debug` (`:1903+`)
+
+- Ships as a `citation` event (copyable Markdown modal, persisted with the message) + stdout
+  mirror, because the status line is `line-clamp-1`/unselectable and `content` is invisible when
+  `output` is non-empty (see `docs/owui-map.md`, frontend constraints).
+- **Provenance-first**: `source`/`matched_key`/rates come from the real resolvers
+  (`_resolve_price`, `_context_size_for` return provenance), so debug can never drift from the
+  actual logic. `matched_key: null` = table-matching miss, the #1 support diagnosis.
+- **Sanitization is a whitelist, not a blacklist** (`_sanitize_model:1784-1823`): `__metadata__`
+  carries the raw prompt (`user_message`), `user_id`, `session_id`, `chat_id` — raw dicts are
+  never included. `llamacpp_url`/`llama_swap_url` are masked `******` in the valves snapshot.
+- Includes a `web_search` hint (server-side web citations detected via http(s)-host URL check) —
+  flags that a provider's search surcharge may be billed outside `usage.cost`.
+
+## Edge-case catalog
+
+Every guard, with its trigger, handling and covering test (`tests/test_usage_display.py`).
+
+| Trigger | Handling | Code | Test |
+|---|---|---|---|
+| `UserValves.enabled=False` | outlet no-op | `:940-942` | `test_outlet_skips_when_user_disabled` |
+| any of the 7 background tasks | early return | `:945-955` | `test_outlet_skips_every_background_task_string` |
+| empty `messages` / no assistant msg | early return | `:957-962` | `test_outlet_no_messages_or_no_assistant` |
+| `usage` `None`/`{}`/non-numeric/negative | all-`None` bag, no crash | `:1036`, `:230-247` | `test_outlet_survives_malformed_usage` |
+| streaming: no `content`, text in `output` | content-first, fall through to output walk | `:291-306` | `test_message_text_prefers_content_then_output` |
+| `output` malformed (non-list, non-dict items, non-str text) | items skipped / coerced | `:268-288` | `test_extract_output_text_*` (4 tests) |
+| `reasoning` items in `output` | excluded from token estimate | `:278` | `test_extract_output_text_only_message_output_text` |
+| tiktoken missing | fallback silently off | `:42-48, :309-312, :1067` | `test_count_tokens_tiktoken_unavailable` |
+| unknown model for tiktoken | `cl100k_base` fallback | `:309-317` | (group A tiktoken tests) |
+| aiohttp missing | all 3 fetchers short-circuit | `:50-57, :1317, :1345, :1658` | `test_*_aiohttp_unavailable_*` (3 tests) |
+| models.dev fetch fails (ctx/price) | `{}` + short retry TTL `min(300, ttl)` | `:1309-1338, :1650-1671` | `test_modelsdev_*_network_error_*` |
+| probe: llama-swap fails | falls back to llama.cpp `/props`; outer except → `None` | `:1340-1374` | `test_probe_context_*` (3 tests) |
+| `_resolve_context`/`_resolve_cost` raise | sentinel dicts, response survives | `:971-980` | `test_outlet_survives_network_resolver_exception` |
+| malformed JSON in `context_size_map`/`price_map` | `{}`; bad entries dropped per-entry | `:1393-1416, :1637-1648` | `test_context_size_map_table_parsing`, `test_price_map_table_*` |
+| map entry value `0` | skipped, falls through to auto sources | `:1274-1275` | `test_context_size_map_zero_value_falls_through` |
+| user map vs live models.dev both match | user map wins (own tier, v2.5.1) | `:1268-1275` | `test_context_size_map_beats_modelsdev` |
+| `num_ctx` non-positive / non-int | rejected | `:1265-1267` | `test_context_num_ctx_hint_rejected_when_not_positive` |
+| workspace model | tables keyed on `base_model_id` | `:387-407` | `test_context_workspace_model_matches_via_base_model_id` |
+| no `__model__` at all | falls back to `body["model"]` | `:405-406` | `test_outlet_falls_back_to_body_model_when_no_model_dict` |
+| no ids for timing key | `fallback:{id(body)}` key | `:903` | `test_inlet_no_metadata_falls_back_to_id_keyed_entry` |
+| module dict lost (restart) | key rebuilt from `chat_id:message_id`; popped after use | `:1181-1190` | `test_resolve_wall_clock_reconstructs_key_from_chat_and_message_id` |
+| stale timing entries | purged >600s on every call | `:1191-1194` | `test_resolve_wall_clock_purges_stale_entries` |
+| `wall_seconds == 0.0` | no div-by-zero (falsy guard) | `:1225-1226` | `test_resolve_timing_zero_wall_seconds_no_divide_by_zero` |
+| provider-reported tps present | beats computed `output/seconds` | `:1214-1221` | `test_resolve_timing_ollama_reported_tps` |
+| proxy folds Anthropic cache into details | treated as subset (no double count) | `:1127-1134` | `test_cache_and_fresh_openai_subset` / `_anthropic_native_on_top` |
+| `auto` mode, no native cost key | never estimates/fetches | `:1442-1446` | `test_resolve_cost_auto_no_native_key_never_estimates` |
+| zero-value token bag | cost `None` | `:1583-1584` | `test_cost_components_zero_token_bag_returns_none` |
+| price missing `input`+`output` rates | cost `None` | `:1561-1564` | `test_cost_components_none_price_or_no_rates` |
+| cache rates missing | default to `input` rate | `:1567-1572` | `test_cost_components_cache_defaults_to_input_rate` |
+| cost below `cost_min_display` | hidden | `:681, :698` | `test_render_cost_estimate_marker_and_threshold` |
+| cumulative == message cost | `💰Σ` suppressed | `:695-699` | `test_render_cost_total_dedupes_when_equal_to_message` |
+| mixed native/estimated history | summed; `≈` if any estimated | `:1459-1479` | `test_resolve_cost_cumulative_mixes_native_and_estimated_messages` |
+| malformed models.dev `api.json` | tolerant per-entry parse | `:1673-1704` | `test_parse_prices_malformed_input_yields_empty_map` |
+| malformed llama-swap `/running` | regex miss → `None` | `:1376-1391` | `test_parse_llama_swap_malformed_input_returns_none` |
+| `display_order` unknown/dup/empty | ignored+debug / dedup / default | `:432-458` | `test_normalize_order_dedups_and_flags_unknown` |
+| reasoning/cached/audio == 0 | hidden (truthiness); context `used=0` still renders | `:597-636` | `test_render_reasoning_hidden_when_zero_or_none`, `test_render_context` |
+| only `source` parts rendered | whole line suppressed | `:1734-1735` | (build_stats tests) |
+| `valves.model_dump()` raises | `{}` snapshot | `:1825-1830` | `test_valves_snapshot_returns_empty_dict_on_dump_failure` |
+| debug `json.dumps` raises | error-string fallback | `:1940-1943` | `test_emit_debug_json_dumps_failure_falls_back_to_error_string` |
+| secret-bearing model/metadata dicts | whitelist copy-out only | `:1784-1823` | `test_sanitize_model_whitelist_only_no_secrets` |
+| RAG/file sources in web-search detect | non-http sources excluded | `:1836-1878` | `test_web_search_debug_ignores_non_web_sources` |
+
+Not handled by design: temporary chats (`local:` chat ids) are not branched on — the plugin works
+purely on what inlet/outlet receive, persistence differences don't affect it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openwebui-token-usage-display"
-version = "2.5.1"
+version = "2.5.2"
 description = "Open WebUI filter plugin: token usage & cost display below each response"
 requires-python = ">=3.11"
 

--- a/usage_display.py
+++ b/usage_display.py
@@ -1,8 +1,11 @@
 """
 title: Token Usage & Cost Display
 author: smetdenis
-version: 2.5.1
-description: Shows token counts (input/output/total, reasoning, cached, audio), generation time, tokens/sec, context-window utilization and message/chat cost below each AI response. The metric order, separator, icon style (emoji/simple/off), compact number format and a cost-display threshold are admin-configurable. Reads OWUI-normalized usage across providers (OpenAI Chat & Responses API, Anthropic, Gemini, Ollama, llama.cpp), falls back to tiktoken. Cost is native when the provider/proxy reports it (OpenRouter/LiteLLM), or optionally estimated from models.dev prices. Context sizes from a built-in table (seeded from models.dev) with optional live models.dev fetch and llama.cpp/llama-swap probing. Works on Open WebUI 0.9.0+ (built around the 0.10.x structured-output/normalized-usage model; degrades gracefully on 0.9.x). tiktoken is optional (soft import). With debug_mode, the diagnostic payload also carries the selected model/provider (sanitized, safe to share), a full cost breakdown with price provenance (incl. the provider's own cost_details when present), a web-search-usage hint, context-window provenance, and a valves snapshot.
+author_url: https://github.com/SmetDenis
+git_url: https://github.com/SmetDenis/openwebui-token-usage-display.git
+version: 2.5.2
+license: MIT
+description: Shows token counts (input/output/total, reasoning, cached, audio), generation time, tokens/sec, context-window utilization and message/chat cost below each AI response. The metric order, separator, icon style (emoji/simple/off), compact number format and a cost-display threshold are admin-configurable. Reads OWUI-normalized usage across providers (OpenAI Chat & Responses API, Anthropic, Gemini, Ollama, llama.cpp), falls back to tiktoken. Cost is native when the provider/proxy reports it (OpenRouter/LiteLLM), or optionally estimated from models.dev prices. Context sizes from a built-in table (seeded from models.dev) with optional live models.dev fetch and llama.cpp/llama-swap probing. Workspace/custom ("agent") models resolve context and cost via their base model. Works on Open WebUI 0.9.0+ (built around the 0.10.x structured-output/normalized-usage model; degrades gracefully on 0.9.x). tiktoken is optional (soft import). With debug_mode, the diagnostic payload also carries the selected model/provider (sanitized, safe to share), a full cost breakdown with price provenance (incl. the provider's own cost_details when present), a web-search-usage hint, context-window provenance, and a valves snapshot.
 required_open_webui_version: 0.9.0
 """
 
@@ -13,9 +16,9 @@ from __future__ import annotations
 #     saved `message["usage"]` is GUARANTEED to carry input_tokens/output_tokens/
 #     total_tokens, while provider-native keys/detail dicts are preserved.
 #     -> primary token read is the normalized triple; provider keys are backup.
-#   * `message["content"]` is NOT persisted for streaming chats (text lives in the
-#     structured `message["output"]` array); it IS present for non-streaming.
-#     -> tiktoken fallback reads content first, then walks `output`.
+#   * `message["content"]` is NOT persisted at 0.10.x — both streaming and
+#     non-streaming save paths write only the structured `message["output"]`
+#     array. -> tiktoken fallback reads content first (0.9.x), then walks `output`.
 #   * `message["info"]` is a redundant mirror ({"usage": ...}) of top-level usage
 #     on persisted chats -> intentionally ignored to avoid double counting.
 #   * Detail keys differ by API: Chat Completions -> prompt_tokens_details /


### PR DESCRIPTION
Rebuilt CLAUDE.md as a compact core that imports two new deep-dive
references, so future work starts with the full picture preloaded.

- docs/plugin-internals.md: pipeline, valves, resolution chains, cache
  semantics, debug payload design and an edge-case catalog mapped to the
  covering tests.
- docs/owui-map.md: navigation map of the Open WebUI source (filter
  machinery, request lifecycle, usage normalization, persistence,
  frontend constraints), verified against v0.10.2.
- README: link the canonical community post and the official Open WebUI
  docs Community Plugins catalog that lists this plugin.
- .gitignore: exclude the machine-local CLAUDE.local.md.
- Corrected a stale NOTE clause: at OWUI 0.10.x message content is not
  persisted for non-streaming completions either - both save paths write
  only the structured output array (verified against v0.10.2).
- Mirrored the version in pyproject.toml and added the CHANGELOG entry.